### PR TITLE
docs: add Building from Source section

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,19 @@ Prompts are stored as markdown files in `~/.config/promptbook/`. Each prompt is 
 | `Cmd+C` | Copy prompt (when not editing) |
 | `E` | Open prompt in editor (menu bar) |
 
-## Quick Start
+## Building from Source
+
+### Prerequisites
+
+- [Rust](https://rustup.rs/) (stable)
+- [Bun](https://bun.sh/) v1.3.5+
+- macOS with Xcode Command Line Tools (`xcode-select --install`)
+
+### Setup
 
 ```bash
+git clone https://github.com/nikuscs/prompt-book.git
+cd prompt-book
 bun install
 bun run tauri:dev
 ```


### PR DESCRIPTION
## Summary

- Added clear "Building from Source" section with prerequisites (Rust, Bun, Xcode CLT)
- Updated Quick Start to detailed setup instructions with repository clone steps
- Helps developers understand the build environment requirements upfront

## Related Changes

This completes the README restructuring started with FAQ section and download links.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nikuscs/prompt-book/pull/3" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
