### PR TITLE
feat: enable updater and drag-sort prompts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,7 @@ jobs:
       version: ${{ steps.bump.outputs.version }}
       tag: ${{ steps.bump.outputs.tag }}
       commit_sha: ${{ steps.commit.outputs.sha }}
+      changelog: ${{ steps.changelog.outputs.changelog }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -113,6 +114,25 @@ jobs:
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "tag=v$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "New version: $NEW_VERSION"
+
+      - name: Generate changelog
+        id: changelog
+        run: |
+          PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -z "$PREV_TAG" ]; then
+            LOG=$(git log --pretty=format:"- %s" --no-merges)
+          else
+            LOG=$(git log "$PREV_TAG"..HEAD --pretty=format:"- %s" --no-merges)
+          fi
+          # Filter out chore: bump commits
+          LOG=$(echo "$LOG" | grep -v "^- chore: bump version" || true)
+          if [ -z "$LOG" ]; then
+            LOG="- Maintenance and bug fixes"
+          fi
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "changelog<<$EOF" >> $GITHUB_OUTPUT
+          echo "$LOG" >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT
 
       - name: Update version files
         run: |
@@ -191,7 +211,9 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          APPLE_SIGNING_IDENTITY: ${{secrets.APPLE_SIGNING_IDENTITY}}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
@@ -199,7 +221,8 @@ jobs:
           tagName: ${{ needs.create-tag.outputs.tag }}
           releaseName: PromptBook v__VERSION__
           releaseBody: |
-            Desktop release for PromptBook.
+            ## What's changed
+            ${{ needs.create-tag.outputs.changelog }}
           releaseDraft: false
           prerelease: false
           projectPath: apps/desktop-tauri

--- a/apps/desktop-tauri/package.json
+++ b/apps/desktop-tauri/package.json
@@ -12,6 +12,10 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.2.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",

--- a/apps/desktop-tauri/src-tauri/Cargo.lock
+++ b/apps/desktop-tauri/src-tauri/Cargo.lock
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "promptbook-desktop"
-version = "0.2.0"
+version = "0.1.3"
 dependencies = [
  "objc2-app-kit",
  "objc2-foundation",

--- a/apps/desktop-tauri/src-tauri/tauri.conf.json
+++ b/apps/desktop-tauri/src-tauri/tauri.conf.json
@@ -55,7 +55,7 @@
     },
     "active": true,
     "targets": ["app", "dmg"],
-    "createUpdaterArtifacts": false,
+    "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
@@ -66,7 +66,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IENFOUQzRkQxRjc1MjQwQkMKUldTOFFGTDMwVCtkem1EUWx4UGhxR0lDcXNRdWUwRkxkc2NCVDRVZXAxVUFoMWtHQy83WDcxRWUK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDRFMEQyNjlFQzlGMjlCRjUKUldUMW0vTEpuaVlOVGxGSGkyTW40cGtiSy92UGJiOEEreWcvQmgwQVc3d3dpVllXbkhGTWd6YXEK",
       "endpoints": [
         "https://github.com/nikuscs/prompt-book/releases/latest/download/latest.json"
       ]

--- a/apps/desktop-tauri/src/App.tsx
+++ b/apps/desktop-tauri/src/App.tsx
@@ -146,6 +146,7 @@ function App() {
     editingTitleId: store.editingTitleId,
     editingTitleValue: store.editingTitleValue,
     focusPromptRequest,
+    reorderPrompts: store.reorderPrompts,
     setSearch: store.setSearch,
     addPrompt: store.addPrompt,
     selectPrompt: store.selectPrompt,

--- a/apps/desktop-tauri/src/components/prompt-card-main.tsx
+++ b/apps/desktop-tauri/src/components/prompt-card-main.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef } from "react";
-import { Check, ChevronDown, Copy, EllipsisVertical, Trash2 } from "lucide-react";
+import { Check, ChevronDown, Copy, EllipsisVertical, GripVertical, Trash2 } from "lucide-react";
 
 import { PromptCardMenu } from "@/components/prompt-card-menu";
 import { getPromptPreview, hasSelectedText } from "@/components/prompt-card-utils";
@@ -9,11 +9,12 @@ import { Textarea } from "@/components/ui/textarea";
 import { usePromptStoreContext } from "@/contexts/prompt-store-context";
 import { usePromptCardMenu } from "@/hooks/use-prompt-card-menu";
 import { UNNAMED_PROMPT_TITLE } from "@/lib/constants";
+import type { DragHandleProps } from "@/types/drag";
 import type { Prompt } from "@/types/prompt";
 
-export function PromptCardMain({ prompt }: { prompt: Prompt }) {
+export function PromptCardMain({ prompt, dragHandle }: { prompt: Prompt; dragHandle?: DragHandleProps }) {
   const store = usePromptStoreContext();
-  const { menuOpen, menuRef, toggleMenu, closeMenu } = usePromptCardMenu();
+  const { menuOpen, menuRef, portalRef, toggleMenu, closeMenu } = usePromptCardMenu();
   const cardRef = useRef<HTMLDivElement>(null);
   const titleEditableRef = useRef<HTMLSpanElement>(null);
 
@@ -77,6 +78,15 @@ export function PromptCardMain({ prompt }: { prompt: Prompt }) {
   return (
     <div ref={cardRef} className="rounded-lg border border-border bg-card" onKeyDownCapture={handleCopyShortcut}>
       <div className="flex items-center gap-1.5 px-2.5 py-1.5">
+        {dragHandle && !isExpanded ? (
+          <div
+            ref={dragHandle.ref}
+            {...dragHandle.listeners}
+            className="flex shrink-0 cursor-grab items-center touch-none active:cursor-grabbing"
+          >
+            <GripVertical className="size-3.5 text-muted-foreground/40" />
+          </div>
+        ) : null}
         <Button size="icon-xs" variant="ghost" className="size-6 rounded-sm text-muted-foreground" onClick={() => store.toggleExpanded(prompt.id)}>
           <ChevronDown className={`size-3.5 text-muted-foreground transition ${isExpanded ? "rotate-180" : ""}`} />
         </Button>
@@ -169,6 +179,8 @@ export function PromptCardMain({ prompt }: { prompt: Prompt }) {
           </ButtonGroup>
           <PromptCardMenu
             open={menuOpen}
+            triggerRef={menuRef}
+            portalRef={portalRef}
             onOpenInEditor={(editor) => {
               store.openInEditor(prompt, editor);
               closeMenu();

--- a/apps/desktop-tauri/src/components/prompt-card-menubar.tsx
+++ b/apps/desktop-tauri/src/components/prompt-card-menubar.tsx
@@ -1,4 +1,4 @@
-import { Check, Copy, EllipsisVertical } from "lucide-react";
+import { Check, Copy, EllipsisVertical, GripVertical } from "lucide-react";
 
 import { PromptCardMenu } from "@/components/prompt-card-menu";
 import { getPromptPreview, hasSelectedText } from "@/components/prompt-card-utils";
@@ -7,14 +7,16 @@ import { ButtonGroup } from "@/components/ui/button-group";
 import { usePromptStoreContext } from "@/contexts/prompt-store-context";
 import { usePromptCardMenu } from "@/hooks/use-prompt-card-menu";
 import { UNNAMED_PROMPT_TITLE } from "@/lib/constants";
+import type { DragHandleProps } from "@/types/drag";
 import type { Prompt } from "@/types/prompt";
 
-export function PromptCardMenubar({ prompt }: { prompt: Prompt }) {
-  const { selectedId, copiedId, selectPrompt, copyPrompt, openInEditor, copyPath, editInMainWindow } = usePromptStoreContext();
-  const { menuOpen, menuRef, toggleMenu, closeMenu } = usePromptCardMenu();
+export function PromptCardMenubar({ prompt, dragHandle }: { prompt: Prompt; dragHandle?: DragHandleProps }) {
+  const { selectedId, copiedId, deleteConfirmId, selectPrompt, copyPrompt, requestDeleteConfirm, deletePrompt, openInEditor, copyPath, editInMainWindow } = usePromptStoreContext();
+  const { menuOpen, menuRef, portalRef, toggleMenu, closeMenu } = usePromptCardMenu();
 
   const selected = prompt.id === selectedId;
   const isCopied = copiedId === prompt.id;
+  const isDeleteConfirm = deleteConfirmId === prompt.id;
 
   const handleCopy = () => copyPrompt(prompt);
 
@@ -34,6 +36,15 @@ export function PromptCardMenubar({ prompt }: { prompt: Prompt }) {
       onKeyDownCapture={handleCopyShortcut}
     >
       <div className="flex items-center gap-1">
+        {dragHandle ? (
+          <div
+            ref={dragHandle.ref}
+            {...dragHandle.listeners}
+            className="flex shrink-0 cursor-grab items-center touch-none active:cursor-grabbing"
+          >
+            <GripVertical className="size-3 text-muted-foreground/40" />
+          </div>
+        ) : null}
         <button className="min-w-0 flex-1 text-left" onClick={() => selectPrompt(prompt.id)}>
           <div className="flex min-w-0 items-center gap-2">
             <span className="shrink-0 whitespace-nowrap text-[11px] font-medium">{prompt.title || UNNAMED_PROMPT_TITLE}</span>
@@ -61,6 +72,8 @@ export function PromptCardMenubar({ prompt }: { prompt: Prompt }) {
           </ButtonGroup>
           <PromptCardMenu
             open={menuOpen}
+            triggerRef={menuRef}
+            portalRef={portalRef}
             onOpenInEditor={(editor) => {
               openInEditor(prompt, editor);
               closeMenu();
@@ -72,6 +85,15 @@ export function PromptCardMenubar({ prompt }: { prompt: Prompt }) {
             onEdit={() => {
               editInMainWindow(prompt);
               closeMenu();
+            }}
+            deleteConfirm={isDeleteConfirm}
+            onDelete={() => {
+              if (isDeleteConfirm) {
+                deletePrompt(prompt.id);
+                closeMenu();
+              } else {
+                requestDeleteConfirm(prompt.id);
+              }
             }}
           />
         </div>

--- a/apps/desktop-tauri/src/components/prompt-list.tsx
+++ b/apps/desktop-tauri/src/components/prompt-list.tsx
@@ -1,16 +1,96 @@
+import { useEffect } from "react";
+import { DndContext, closestCenter, PointerSensor, useSensor, useSensors, type DragEndEvent } from "@dnd-kit/core";
+import { restrictToVerticalAxis, restrictToParentElement } from "@dnd-kit/modifiers";
+import { SortableContext, verticalListSortingStrategy, useSortable, arrayMove } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+
 import { PromptCardMain } from "@/components/prompt-card-main";
 import { PromptCardMenubar } from "@/components/prompt-card-menubar";
 import { usePromptStoreContext } from "@/contexts/prompt-store-context";
+import type { Prompt } from "@/types/prompt";
 
-export function PromptList({ variant }: { variant: "main" | "menubar" }) {
-  const { filteredPrompts } = usePromptStoreContext();
-  const Card = variant === "main" ? PromptCardMain : PromptCardMenubar;
+function SortableItem({ prompt, variant }: { prompt: Prompt; variant: "main" | "menubar" }) {
+  const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition } = useSortable({ id: prompt.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  const dragHandle = { ref: setActivatorNodeRef, listeners };
 
   return (
-    <div className="space-y-1.5">
-      {filteredPrompts.map((prompt) => (
-        <Card key={prompt.id} prompt={prompt} />
-      ))}
+    <div ref={setNodeRef} style={style} {...attributes} className="outline-none">
+      {variant === "main" ? (
+        <PromptCardMain prompt={prompt} dragHandle={dragHandle} />
+      ) : (
+        <PromptCardMenubar prompt={prompt} dragHandle={dragHandle} />
+      )}
     </div>
+  );
+}
+
+export function PromptList({ variant }: { variant: "main" | "menubar" }) {
+  const { filteredPrompts, search, selectedId, selectPrompt, reorderPrompts } = usePromptStoreContext();
+  const isSearching = search.trim().length > 0;
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return;
+      if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) return;
+      if ((event.target as HTMLElement).isContentEditable) return;
+
+      if (filteredPrompts.length === 0) return;
+      const idx = filteredPrompts.findIndex((p) => p.id === selectedId);
+      const next = event.key === "ArrowDown"
+        ? Math.min(idx + 1, filteredPrompts.length - 1)
+        : Math.max(idx - 1, 0);
+      if (next === idx) return;
+
+      const target = filteredPrompts[next];
+      if (!target) return;
+      event.preventDefault();
+      selectPrompt(target.id);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [filteredPrompts, selectedId, selectPrompt]);
+
+  if (isSearching) {
+    const Card = variant === "main" ? PromptCardMain : PromptCardMenubar;
+    return (
+      <div className="space-y-1.5">
+        {filteredPrompts.map((prompt) => (
+          <Card key={prompt.id} prompt={prompt} />
+        ))}
+      </div>
+    );
+  }
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const oldIndex = filteredPrompts.findIndex((p) => p.id === active.id);
+    const newIndex = filteredPrompts.findIndex((p) => p.id === over.id);
+    if (oldIndex === -1 || newIndex === -1) return;
+    reorderPrompts(arrayMove(filteredPrompts, oldIndex, newIndex));
+  };
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      modifiers={[restrictToVerticalAxis, restrictToParentElement]}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext items={filteredPrompts.map((p) => p.id)} strategy={verticalListSortingStrategy}>
+        <div className="space-y-1.5">
+          {filteredPrompts.map((prompt) => (
+            <SortableItem key={prompt.id} prompt={prompt} variant={variant} />
+          ))}
+        </div>
+      </SortableContext>
+    </DndContext>
   );
 }

--- a/apps/desktop-tauri/src/contexts/prompt-store-context.tsx
+++ b/apps/desktop-tauri/src/contexts/prompt-store-context.tsx
@@ -16,6 +16,7 @@ export type PromptStoreContextType = {
   addPrompt: () => string;
   selectPrompt: (id: string) => void;
   toggleExpanded: (id: string) => void;
+  reorderPrompts: (reordered: Prompt[]) => void;
   copyPrompt: (prompt: Prompt) => void;
   changeContent: (id: string, value: string) => void;
   startEditTitle: (prompt: Prompt) => void;

--- a/apps/desktop-tauri/src/hooks/use-prompt-card-menu.ts
+++ b/apps/desktop-tauri/src/hooks/use-prompt-card-menu.ts
@@ -3,13 +3,15 @@ import { useCallback, useEffect, useRef, useState } from "react";
 export function usePromptCardMenu() {
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+  const portalRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!menuOpen) return;
     const onMouseDown = (event: MouseEvent) => {
-      if (!menuRef.current?.contains(event.target as Node)) {
-        setMenuOpen(false);
-      }
+      const target = event.target as Node;
+      if (menuRef.current?.contains(target)) return;
+      if (portalRef.current?.contains(target)) return;
+      setMenuOpen(false);
     };
     window.addEventListener("mousedown", onMouseDown);
     return () => window.removeEventListener("mousedown", onMouseDown);
@@ -18,5 +20,5 @@ export function usePromptCardMenu() {
   const toggleMenu = useCallback(() => setMenuOpen((prev) => !prev), []);
   const closeMenu = useCallback(() => setMenuOpen(false), []);
 
-  return { menuOpen, menuRef, toggleMenu, closeMenu };
+  return { menuOpen, menuRef, portalRef, toggleMenu, closeMenu };
 }

--- a/apps/desktop-tauri/src/hooks/use-prompt-store.ts
+++ b/apps/desktop-tauri/src/hooks/use-prompt-store.ts
@@ -128,6 +128,10 @@ export function usePromptStore() {
     setTimeout(() => setDeleteConfirmId((prev) => (prev === id ? null : prev)), DELETE_CONFIRM_TIMEOUT_MS);
   };
 
+  const reorderPrompts = (reordered: Prompt[]) => {
+    updatePrompts(reordered);
+  };
+
   const openPromptInEditor = async (prompt: Prompt, editor: "cursor" | "vscode" | "zed") => {
     try {
       await invoke("open_prompt_in_editor", { editor, title: prompt.title, content: prompt.content });
@@ -169,6 +173,7 @@ export function usePromptStore() {
     copyPrompt,
     deletePrompt,
     requestDeleteConfirm,
+    reorderPrompts,
     openPromptInEditor,
     copyPromptPath,
     reloadPrompts,

--- a/apps/desktop-tauri/src/types/drag.ts
+++ b/apps/desktop-tauri/src/types/drag.ts
@@ -1,0 +1,8 @@
+import type { useSortable } from "@dnd-kit/sortable";
+
+type SortableReturn = ReturnType<typeof useSortable>;
+
+export type DragHandleProps = {
+  ref: SortableReturn["setActivatorNodeRef"];
+  listeners: SortableReturn["listeners"];
+};

--- a/bun.lock
+++ b/bun.lock
@@ -10,9 +10,13 @@
     },
     "apps/desktop-tauri": {
       "name": "@promptbook/desktop-tauri",
-      "version": "0.2.0",
+      "version": "0.1.3",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@radix-ui/react-scroll-area": "^1.2.10",
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
@@ -92,6 +96,16 @@
     "@base-ui/react": ["@base-ui/react@1.2.0", "", { "dependencies": { "@babel/runtime": "^7.28.6", "@base-ui/utils": "0.2.5", "@floating-ui/react-dom": "^2.1.6", "@floating-ui/utils": "^0.2.10", "tabbable": "^6.4.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-O6aEQHcm+QyGTFY28xuwRD3SEJGZOBDpyjN2WvpfWYFVhg+3zfXPysAILqtM0C1kWC82MccOE/v1j+GHXE4qIw=="],
 
     "@base-ui/utils": ["@base-ui/utils@0.2.5", "", { "dependencies": { "@babel/runtime": "^7.28.6", "@floating-ui/utils": "^0.2.10", "reselect": "^5.1.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-oYC7w0gp76RI5MxprlGLV0wze0SErZaRl3AAkeP3OnNB/UBMb6RqNf6ZSIlxOc9Qp68Ab3C2VOcJQyRs7Xc7Vw=="],
+
+    "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
+
+    "@dnd-kit/core": ["@dnd-kit/core@6.3.1", "", { "dependencies": { "@dnd-kit/accessibility": "^3.1.1", "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ=="],
+
+    "@dnd-kit/modifiers": ["@dnd-kit/modifiers@9.0.0", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.3.0", "react": ">=16.8.0" } }, "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw=="],
+
+    "@dnd-kit/sortable": ["@dnd-kit/sortable@10.0.0", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.3.0", "react": ">=16.8.0" } }, "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg=="],
+
+    "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
 


### PR DESCRIPTION
## Summary

- Enable Tauri auto-updater with cryptographic signing (latest.json + .sig artifacts)
- Add changelog generation to release workflow for better release notes
- Implement drag-and-drop prompt reordering with DnD Kit
- Fix crash when navigating empty prompt list with arrow keys

## Testing

Run `bun run typecheck` to verify all type checks pass (tsc, cargo check, oxlint, clippy).
Once merged and released, existing installs will auto-detect updates from GitHub Releases.

🤖 Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nikuscs/prompt-book/pull/6" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
