### PR TITLE
chore: require approval for release-sensitive workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,12 @@ jobs:
     runs-on: macos-latest
     permissions:
       contents: read
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]'))
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,7 @@ jobs:
     name: Create Tag
     needs: checks
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
     outputs:
@@ -238,6 +239,7 @@ jobs:
     needs: [create-tag, build-and-release]
     if: failure() && needs.create-tag.result == 'success'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Summary
- add a fork-origin guard to PR-triggered CI so fork PR jobs do not run
- disable persisted checkout credentials in CI checkout
- bind version/tag creation and failure cleanup jobs to the protected `release` environment
- keep Apple/Tauri signing jobs under the existing protected `release` environment

## Validation
- parsed workflow YAML locally
- ran `git diff --check`
- verified `release` environment has required reviewers configured

## Notes
- This PR intentionally does not restrict `allowed_actions`; that remains deferred to avoid broad workflow churn.